### PR TITLE
Make comments field multiline (UITextView)

### DIFF
--- a/Classes/Base.lproj/LEEditController-iPad.xib
+++ b/Classes/Base.lproj/LEEditController-iPad.xib
@@ -19,7 +19,6 @@
                 <outlet property="datePicker" destination="560" id="652"/>
                 <outlet property="idApproaches" destination="570" id="653"/>
                 <outlet property="idCFI" destination="592" id="655"/>
-                <outlet property="idComments" destination="577" id="656"/>
                 <outlet property="idDate" destination="582" id="657"/>
                 <outlet property="idDayLandings" destination="571" id="659"/>
                 <outlet property="idDual" destination="593" id="660"/>
@@ -743,11 +742,11 @@
             </connections>
             <point key="canvasLocation" x="360.9375" y="-71.484375"/>
         </tableViewCell>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="cellComments" id="563" customClass="EditCell">
-            <rect key="frame" x="0.0" y="0.0" width="768" height="44"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="cellComments" rowHeight="76" id="563" customClass="EditCell">
+            <rect key="frame" x="0.0" y="0.0" width="768" height="76"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="563" id="Szo-0z-44I">
-                <rect key="frame" x="0.0" y="0.0" width="768" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="768" height="76"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" text="Comments:" lineBreakMode="tailTruncation" minimumFontSize="10" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="576">
@@ -759,32 +758,31 @@
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <textField opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="577" userLabel="txtComments">
-                        <rect key="frame" x="15" y="19" width="69.5" height="19"/>
+                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f6l-xp-dfB" userLabel="txtComments">
+                        <rect key="frame" x="11" y="14" width="761" height="62"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="textColor" systemColor="labelColor"/>
                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences" autocorrectionType="yes"/>
                         <connections>
-                            <outlet property="delegate" destination="-1" id="705"/>
+                            <outlet property="delegate" destination="-1" id="90s-QQ-7LB"/>
                         </connections>
-                    </textField>
+                    </textView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="577" firstAttribute="width" secondItem="576" secondAttribute="width" id="FoH-07-kAF"/>
+                    <constraint firstItem="f6l-xp-dfB" firstAttribute="leading" secondItem="Szo-0z-44I" secondAttribute="leadingMargin" constant="-5" id="H8M-jQ-YZ3"/>
                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="576" secondAttribute="trailing" constant="20" symbolic="YES" id="Hcb-2T-VQi"/>
                     <constraint firstItem="576" firstAttribute="top" secondItem="Szo-0z-44I" secondAttribute="top" constant="2" id="Iwb-Kc-oTj"/>
-                    <constraint firstItem="577" firstAttribute="leading" secondItem="576" secondAttribute="leading" id="T3B-Ug-qVM"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="f6l-xp-dfB" secondAttribute="trailing" constant="-20" id="O7N-wH-DtK"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="f6l-xp-dfB" secondAttribute="bottom" constant="-11" id="Syi-7x-pMP"/>
+                    <constraint firstItem="f6l-xp-dfB" firstAttribute="top" secondItem="Szo-0z-44I" secondAttribute="topMargin" constant="3" id="oR7-AY-QoI"/>
                     <constraint firstItem="576" firstAttribute="leading" secondItem="Szo-0z-44I" secondAttribute="leadingMargin" id="oYf-y1-PXG"/>
-                    <constraint firstItem="577" firstAttribute="top" secondItem="576" secondAttribute="bottom" constant="2" id="vBn-HA-e8c"/>
-                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="577" secondAttribute="trailing" constant="20" symbolic="YES" id="x9V-Fw-zrI"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
-                <outlet property="firstResponderControl" destination="577" id="636"/>
-                <outlet property="lastResponderControl" destination="577" id="637"/>
                 <outlet property="lbl" destination="576" id="691"/>
-                <outlet property="txt" destination="577" id="690"/>
             </connections>
-            <point key="canvasLocation" x="360.9375" y="-19.921875"/>
+            <point key="canvasLocation" x="360.9375" y="-10.546875"/>
         </tableViewCell>
         <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="cellLandings" rowHeight="88" id="565" customClass="NavigableCell">
             <rect key="frame" x="0.0" y="0.0" width="768" height="88"/>

--- a/Classes/Base.lproj/LEEditController.xib
+++ b/Classes/Base.lproj/LEEditController.xib
@@ -128,11 +128,11 @@
             </connections>
             <point key="canvasLocation" x="-73.599999999999994" y="464.16791604197903"/>
         </tableViewCell>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="cellComments" rowHeight="45" id="321" customClass="EditCell">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="45"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="cellComments" rowHeight="76" id="321" customClass="EditCell">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="76"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="321" id="DL7-HT-psE">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="45"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="76"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" text="Comments:" lineBreakMode="tailTruncation" minimumFontSize="10" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="330">
@@ -141,22 +141,23 @@
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <textField opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="333" userLabel="txtComments">
-                        <rect key="frame" x="15" y="21.5" width="259" height="19"/>
+                    <textView opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="333" userLabel="txtComments">
+                        <rect key="frame" x="12" y="18.5" width="292" height="56.5"/>
                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences" autocorrectionType="yes"/>
                         <connections>
                             <outlet property="delegate" destination="-1" id="335"/>
                         </connections>
-                    </textField>
+                    </textView>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="333" secondAttribute="trailing" constant="20" symbolic="YES" id="CvH-Pe-raq"/>
-                    <constraint firstItem="333" firstAttribute="leading" secondItem="330" secondAttribute="leading" id="OkQ-e5-o6r"/>
-                    <constraint firstItem="333" firstAttribute="width" secondItem="330" secondAttribute="width" id="RYD-7w-0uI"/>
+                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="333" secondAttribute="trailing" constant="15" id="CvH-Pe-raq"/>
+                    <constraint firstItem="333" firstAttribute="leading" secondItem="330" secondAttribute="leading" constant="-4" id="OkQ-e5-o6r"/>
+                    <constraint firstItem="333" firstAttribute="width" secondItem="330" secondAttribute="width" constant="34" id="RYD-7w-0uI"/>
                     <constraint firstItem="330" firstAttribute="leading" secondItem="DL7-HT-psE" secondAttribute="leadingMargin" id="UBL-tT-F0v"/>
                     <constraint firstItem="330" firstAttribute="top" secondItem="DL7-HT-psE" secondAttribute="topMargin" constant="-6" id="W9N-lQ-eIV"/>
-                    <constraint firstItem="333" firstAttribute="top" secondItem="330" secondAttribute="bottom" constant="2" id="ZLk-FA-gLM"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="333" secondAttribute="bottom" constant="-10" id="XJb-bY-lTV"/>
+                    <constraint firstItem="333" firstAttribute="top" secondItem="330" secondAttribute="bottom" constant="-1" id="ZLk-FA-gLM"/>
                     <constraint firstAttribute="trailing" secondItem="330" secondAttribute="trailing" constant="46" id="fGY-4w-qpD"/>
                 </constraints>
             </tableViewCellContentView>
@@ -164,7 +165,7 @@
                 <outlet property="firstResponderControl" destination="333" id="546"/>
                 <outlet property="lastResponderControl" destination="333" id="547"/>
             </connections>
-            <point key="canvasLocation" x="-73.599999999999994" y="392.65367316341832"/>
+            <point key="canvasLocation" x="-73.599999999999994" y="406.59670164917543"/>
         </tableViewCell>
         <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="cellRoute" rowHeight="45" id="314" customClass="EditCell">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>

--- a/Classes/FlightEditorBaseTableViewController.h
+++ b/Classes/FlightEditorBaseTableViewController.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) IBOutlet UITextField * idDate;
 @property (nonatomic, strong) IBOutlet UITextField * idRoute;
-@property (nonatomic, strong) IBOutlet UITextField * idComments;
+@property (nonatomic, strong) IBOutlet UITextView * idComments;
 @property (nonatomic, strong) IBOutlet UITextField * idTotalTime;
 @property (nonatomic, strong) IBOutlet UITextField * idPopAircraft;
 @property (nonatomic, strong) IBOutlet UITextField * idApproaches;

--- a/Classes/LogbookEntryBaseTableViewController.m
+++ b/Classes/LogbookEntryBaseTableViewController.m
@@ -59,7 +59,6 @@
     self.navigationItem.rightBarButtonItem.enabled = NO;
     self.navigationItem.rightBarButtonItem.enabled = YES;
     
-    self.idComments.placeholder = NSLocalizedString(@"Comments", @"Entry field: Comments");
     self.idRoute.placeholder = NSLocalizedString(@"Route", @"Entry field: Route");
     self.idPopAircraft.placeholder = NSLocalizedString(@"Aircraft", @"Entry field: Aircraft");
     


### PR DESCRIPTION
Hi @ericberman 👋 

Here is a minimal diff that turns the comments field into a multiline component (UITextView).

I went with 3 lines of visible text for the comments field to balance the height of the row with the rest of the already complex view.

There is likely some finesse to be added, but I wanted to get this up for your input and feedback.

<img width="528" alt="Screen Shot 2021-11-14 at 4 48 06 PM" src="https://user-images.githubusercontent.com/1594130/141699890-5b1e1fd7-f27f-4423-9340-973150af83ca.png">

![Screen Shot 2021-11-15 at 5 10 16 PM](https://user-images.githubusercontent.com/1594130/141860933-52772184-9270-44ea-a7f2-e46d729bd632.png)

(My phone is a 12 mini these days, so that's what I picked for the simulator in the screenshot here)

Closes #241 